### PR TITLE
docs: fix typo(competions → completions)

### DIFF
--- a/command/shell_completions.md
+++ b/command/shell_completions.md
@@ -35,7 +35,7 @@ await new Command()
 
 ## Complete method
 
-Another way to add competions is by registering a completions action with the
+Another way to add completions is by registering a completions action with the
 `.complete()` method. The values returned by the `.complete()` method will be
 used for shell completions.
 


### PR DESCRIPTION
This PR fix a small typo in command/shell_completions.
Thanks for making such a nice CLI tool!😆