### PR TITLE
Fix a small typo in build_in_commands.md

### DIFF
--- a/command/built_in_commands.md
+++ b/command/built_in_commands.md
@@ -1,4 +1,4 @@
-# Build-in commands
+# Built-in commands
 
 Cliffy provides some predefined commands like `help`, `completions` and
 `upgrade`. These commands are optional and must be registered manually if you

--- a/command/built_in_commands.md
+++ b/command/built_in_commands.md
@@ -143,7 +143,7 @@ If your cli needs some permissions you can specify the permissions with the
 
 ### Providers
 
-There are three build in providers: `deno.land`, `nest.land` and `github`. If
+There are three built-in providers: `deno.land`, `nest.land` and `github`. If
 multiple providers are registered, you can specify the registry that should be
 used with the `--registry` option. The github provider can also be used to
 `upgrade` to any git branch.

--- a/command/commands.md
+++ b/command/commands.md
@@ -282,7 +282,7 @@ $ deno run https://deno.land/x/cliffy/examples/command/global_commands.ts comman
 With the `.noGlobals()` method you can disable inheriting global _commands_,
 _options_ and _environment variables_ from parent commands.
 
-> The build-in `--help` option and the `help` command are excluded from the
+> The built-in `--help` option and the `help` command are excluded from the
 > `.noGlobals()` method.
 
 ```ts

--- a/command/help.md
+++ b/command/help.md
@@ -5,7 +5,7 @@ on your commands. The name, version, description, meta information, options,
 commands, environment variables and examples are displayed in the help.
 
 To display the help you can invoke the [help option](#help-option) (`-h` or
-`--help`) or the [help command](./build_in_commands.md#help-command) (`help`) on
+`--help`) or the [help command](./built_in_commands.md#help-command) (`help`) on
 the main or on one of the sub commands. The `help` command needs to be
 registered manually.
 
@@ -128,7 +128,7 @@ description. With the long flag (`--help`) the full description is printed for
 each option and command.
 
 Optionally you can also register the pre-defined
-[help](./build_in_commands.md#help-command) command to display the help.
+[help](./built_in_commands.md#help-command) command to display the help.
 
 ### Customize help option
 

--- a/command/index.md
+++ b/command/index.md
@@ -3,7 +3,7 @@
 The complete and type safe solution for building command-line interfaces.
 
 The command module supports type safe options and arguments, input validation,
-auto generated help, build-in shell completions, and more.
+auto generated help, built-in shell completions, and more.
 
 ## Usage
 

--- a/command/others.md
+++ b/command/others.md
@@ -2,7 +2,7 @@
 
 ## Did you mean
 
-Cliffy has build-in _did-you-mean_ support to improve the user and developer
+Cliffy has built-in _did-you-mean_ support to improve the user and developer
 experience. For example, cliffy prints some suggestions, when the user executes
 an invalid command, or the developer has a typo in the name of a type.
 

--- a/command/shell_completions.md
+++ b/command/shell_completions.md
@@ -2,14 +2,14 @@
 
 Cliffy supports shell completion out of the box. To enable shell completions it
 is required to register the
-[completions](./build_in_commands.md#completions-command) command.
+[completions](./built_in_commands.md#completions-command) command.
 
 The completions command generates a shell completions script for your specific
 shell environment. Currently supported shells are:
 
-- [bash](./build_in_commands.md#bash-completions)
-- [fish](./build_in_commands.md#fish-completions)
-- [zsh](./build_in_commands.md#zsh-completions)
+- [bash](./built_in_commands.md#bash-completions)
+- [fish](./built_in_commands.md#fish-completions)
+- [zsh](./built_in_commands.md#zsh-completions)
 
 The completions script enables completions for all sub-commands, options and
 arguments.

--- a/command/types.md
+++ b/command/types.md
@@ -9,7 +9,7 @@ Types can be declared after the argument name, separated by colon `<name:type>`.
 If no type is specified, the type defaults to `string`. If an option with no
 arguments is defined the type defaults to `true`.
 
-## Build-in types
+## Built-in types
 
 Following types are available by default on all commands.
 

--- a/flags/index.md
+++ b/flags/index.md
@@ -1,6 +1,6 @@
 # Flags
 
-Command line arguments parser with build-in validations.
+Command line arguments parser with built-in validations.
 
 ## Usage
 

--- a/flags/parse_options.md
+++ b/flags/parse_options.md
@@ -14,7 +14,7 @@ With the `parse` method you can add a custom handler for handling and parsing
 types.
 
 > ❗ The `parse` method will be called for all types, which means it overrides
-> also all build in types!
+> also all built-in types!
 
 ```typescript
 import {

--- a/toc.yaml
+++ b/toc.yaml
@@ -11,7 +11,7 @@
         /environment-variables: Environment variables
         /help: Help
         /shell-completions: Shell completions
-        /build-in-commands: Build-in commands
+        /built-in-commands: Built-in commands
         /error-handling: Error handling
         /generics: Generics
         /others: Others


### PR DESCRIPTION
This should read `built-in commands`. The file has also been renamed to match.