### PR TITLE
docs(command): add warning about spaces in names for upgrade command

### DIFF
--- a/command/built_in_commands.md
+++ b/command/built_in_commands.md
@@ -131,10 +131,13 @@ With the `provider` option you specify which registries are supported. This
 option is required.
 
 The `main` option is the entry file of your cli. With the `name` option you can
-optional define the name of your cli which defaults to the name of your main
+optionally define the name of your cli which defaults to the name of your main
 file (`[name].ts`).
 
-If your cli needs some permissions you can specify the permissions with the
+> ❗️ The name cannot have spaces! If you use spaces, you (or your users!) will
+> get an error when upgrading.
+
+If your cli needs some permissions, you can specify the permissions with the
 `args` option which are passed to `deno install`.
 
 > - When `args` is defined, `--force` and `--name` is set by default.

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/x/night_owl@v0.1.24/mod.ts";
+import { serve } from "https://deno.land/x/night_owl@v0.1.27/mod.ts";
 
 await serve({
   name: "Cliffy",


### PR DESCRIPTION
Servus @c4spar, I encountered this issue a few days ago. It would be good to warn people that having spaces in the name of the main command will cause problems. I expected things to be fine because I was installing with `--name whatever`, but instead I got an unhelpful error message. At minimum such a warning in the documentation would help.

I think it would be better if there were an explicit check [here](https://github.com/c4spar/deno-cliffy/blob/bcc755206e8f1bb8ae1658d4f8b34cf82c3923c5/command/upgrade/provider.ts#L111) that checks to see if there are spaces in the name, and throws a friendly message if there are. If you think that's a good idea, I can open a PR in the main repo for it.

Additionally there were two minor grammar issues in the same area that I've improved.