### PR TITLE
correct methods' name & hide unavaible guide

### DIFF
--- a/command/index.md
+++ b/command/index.md
@@ -140,7 +140,7 @@ await new Command()
 ```
 
 > To make types, options and environment variables also available on child
-> commands you can use the [.globalOptions()](./options.md#global-options),
+> commands you can use the [.globalOption()](./options.md#global-options),
 > [.globalEnv()](./environment_variables.md#global-environment-variables) and
 > [.globalType()](./types.md#global-types) methods.
 

--- a/command/options.md
+++ b/command/options.md
@@ -4,7 +4,7 @@ Options are defined with the `.option()` method and can be accessed as
 properties on the options object which is passed to the `.action()` handler and
 returned by the `.parse()` method.
 
-With the first argument of the `.options()` method you define the option names
+With the first argument of the `.option()` method you define the option names
 and arguments. Each option can have multiple short and long flags, separated by
 comma. The name of the first long flag will be unused as an option name. If no
 long flag is provided the first short flag will be used.
@@ -14,7 +14,7 @@ Multi-word options such as `--template-engine` are camel-cased to
 example `-abc` is equivalent to `-a -b -c` and `-n5` is equivalent to `-n 5` and
 `-n=5`.
 
-The second parameter of the `.options()` method is the description and the third
+The second parameter of the `.option()` method is the description and the third
 parameter can be an options object.
 
 ## Arguments

--- a/prompt/types/select.md
+++ b/prompt/types/select.md
@@ -33,7 +33,7 @@ specific options.
 
 With the `options` option you specify an array of options. An option can be
 either a string or an options object. Options can be also nested, see
-[options](#child-options).
+[child options](#child-options).
 
 #### Select option
 

--- a/table/columns.md
+++ b/table/columns.md
@@ -49,4 +49,4 @@ The `.padding()` method adds padding to all cell's in this column.
 ### Set multiple options
 
 The `.options()` method allows you to set multiple options at once by passing an
-options bag to the `.options()` method. -->
+options bag to the `.options()` method.

--- a/table/columns.md
+++ b/table/columns.md
@@ -46,7 +46,7 @@ You can set the min and max width of columns with the `.minColWidth()` and
 
 The `.padding()` method adds padding to all cell's in this column.
 
-<!-- ### Set multiple options
+### Set multiple options
 
 The `.options()` method allows you to set multiple options at once by passing an
 options bag to the `.options()` method. -->

--- a/table/columns.md
+++ b/table/columns.md
@@ -46,7 +46,7 @@ You can set the min and max width of columns with the `.minColWidth()` and
 
 The `.padding()` method adds padding to all cell's in this column.
 
-### Set multiple options
+<!-- ### Set multiple options
 
 The `.options()` method allows you to set multiple options at once by passing an
-options bag to the `.options()` method.
+options bag to the `.options()` method. -->


### PR DESCRIPTION
+ most typo is about plural
+ hide the last section in table/columns.md (no `options()` was found in latest version)